### PR TITLE
cheroot 11.1.2: update for py314 support

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,5 @@
 {% set name = "cheroot" %}
 {% set version = "10.0.1" %}
-{% set tests_to_ignore = " --ignore=${SP_DIR}/cheroot/test/test_server.py" %}  # [unix]
-{% set tests_to_ignore = " --ignore=%SP_DIR%/cheroot/test/test_server.py" %}  # [win]
-{% set tests_to_ignore = 'tests_to_ignore + " --ignore=${SP_DIR}/cheroot/test/test_wsgi.py"' %}  # [unix]
-{% set tests_to_ignore = 'tests_to_ignore + " --ignore=%SP_DIR%/cheroot/test/test_wsgi.py"' %}  # [win]
-{% set tests_to_ignore = 'tests_to_ignore + " --ignore=%SP_DIR%/cheroot/test/test_ssl.py"' %}  # [win]
 
 package:
   name: {{ name|lower }}
@@ -34,10 +29,18 @@ requirements:
     - more-itertools >=2.6
     - jaraco.functools
 
+{% set tests_to_ignore = "" %}
 # E   ModuleNotFoundError: No module named 'requests_unixsocket'
+{% set tests_to_ignore = " --ignore=${SP_DIR}/cheroot/test/test_server.py" %}  # [unix]
+{% set tests_to_ignore = " --ignore=%SP_DIR%/cheroot/test/test_server.py" %}  # [win]
 # E   ModuleNotFoundError: No module named 'requests_toolbelt'
+{% set tests_to_ignore = tests_to_ignore + " --ignore=${SP_DIR}/cheroot/test/test_wsgi.py" %}  # [unix]
+{% set tests_to_ignore = tests_to_ignore + " --ignore=%SP_DIR%/cheroot/test/test_wsgi.py" %}  # [win]
+
 # On Windows, the SSL handshake failure is producing an error message that differs from all the predefined expected patterns,
 # causing the assertion assert any(e in err_text for e in expected_substrings) to fail since none of the expected substring patterns are found in the actual error text.
+{% set tests_to_ignore = tests_to_ignore + " --ignore=%SP_DIR%/cheroot/test/test_ssl.py" %}  # [win]
+
 test:
   imports:
     - cheroot

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,25 @@
 {% set name = "cheroot" %}
 {% set version = "10.0.1" %}
+{% set tests_to_ignore = " --ignore=${SP_DIR}/cheroot/test/test_server.py" %}  # [unix]
+{% set tests_to_ignore = " --ignore=%SP_DIR%/cheroot/test/test_server.py" %}  # [win]
+{% set tests_to_ignore = 'tests_to_ignore + " --ignore=${SP_DIR}/cheroot/test/test_wsgi.py"' %}  # [unix]
+{% set tests_to_ignore = 'tests_to_ignore + " --ignore=%SP_DIR%/cheroot/test/test_wsgi.py"' %}  # [win]
+{% set tests_to_ignore = 'tests_to_ignore + " --ignore=%SP_DIR%/cheroot/test/test_ssl.py"' %}  # [win]
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: e0b82f797658d26b8613ec8eb563c3b08e6bd6a7921e9d5089bd1175ad1b1740
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - cheroot = cheroot.cli:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<36]
+  skip: true  # [py<36]
 
 requirements:
   host:
@@ -30,16 +35,9 @@ requirements:
     - jaraco.functools
 
 # E   ModuleNotFoundError: No module named 'requests_unixsocket'
-{% set tests_to_ignore = " --ignore=${SP_DIR}/cheroot/test/test_server.py" %}  # [unix]
-{% set tests_to_ignore = " --ignore=%SP_DIR%/cheroot/test/test_server.py" %}  # [win]
 # E   ModuleNotFoundError: No module named 'requests_toolbelt'
-{% set tests_to_ignore = tests_to_ignore + " --ignore=${SP_DIR}/cheroot/test/test_wsgi.py" %}  # [unix]
-{% set tests_to_ignore = tests_to_ignore + " --ignore=%SP_DIR%/cheroot/test/test_wsgi.py" %}  # [win]
-
 # On Windows, the SSL handshake failure is producing an error message that differs from all the predefined expected patterns,
 # causing the assertion assert any(e in err_text for e in expected_substrings) to fail since none of the expected substring patterns are found in the actual error text.
-{% set tests_to_ignore = tests_to_ignore + " --ignore=%SP_DIR%/cheroot/test/test_ssl.py" %}  # [win]
-
 test:
   imports:
     - cheroot

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,31 +1,29 @@
-{% set name = "cheroot" %}
-{% set version = "10.0.1" %}
+{% set name = "Cheroot" %}
+{% set version = "11.1.2" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e0b82f797658d26b8613ec8eb563c3b08e6bd6a7921e9d5089bd1175ad1b1740
+  url: https://pypi.org/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name|lower }}-{{ version }}.tar.gz
+  sha256: bfb70c49663f63b0440f2b54dbc6b0d1650e56dfe4e2641f59b2c6f727b44aca
 
 build:
-  number: 1
+  number: 0
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - cheroot = cheroot.cli:main
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<36]
 
 requirements:
   host:
     - python
     - pip
-    - wheel
-    - setuptools >=34.4
+    - setuptools >=61.2
     - setuptools-scm >=7.0.0
   run:
     - python
-    - importlib-metadata  # [py<38]
     - more-itertools >=2.6
     - jaraco.functools
 
@@ -44,7 +42,6 @@ requirements:
 test:
   imports:
     - cheroot
-    - cheroot._compat
     - cheroot.cli
     - cheroot.server
     - cheroot.test
@@ -56,8 +53,11 @@ test:
     - pytest -v %SP_DIR%/cheroot/test {{ tests_to_ignore }}  # [win]
   requires:
     - pip
-    - pytest >=4.6.6,<7
+    - pytest >=7
     - pytest-mock >=1.11.0
+    - pytest-rerunfailures
+    - pytest-sugar >=0.9.3
+    - pytest-xdist >=1.28.0
     - requests
     - jaraco.text >=3.1
     - pyopenssl >=22
@@ -66,7 +66,7 @@ test:
 
 about:
   home: https://cheroot.cherrypy.dev
-  summary: Highly-optimized, pure-python HTTP server
+  summary: Cheroot is the high-performance, pure-Python HTTP server used by CherryPy.
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.md


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira]() 
- [Upstream repository]()

### Explanation of changes:

- Build configuration updates
Skip condition: changed to # [py<38]
Removed wheel from host requirements (no longer needed)

- Build dependencies modernization
setuptools: >=34.4 → >=61.2

- Runtime requirements cleanup
Removed importlib-metadata # [py<38] (no longer needed)

- Test imports update
Removed cheroot._compat from test imports

- Test dependencies updates
pytest >=7

Added:
pytest-mock >=1.11.0
pytest-rerunfailures
pytest-sugar >=0.9.3
pytest-xdist >=1.28.0
requests
jaraco.text >=3.1
pyopenssl >=22

- Package description update

### Notes:

-